### PR TITLE
Modify expired milestone for jxl

### DIFF
--- a/0001-Restore-libjxl-in-Thorium.patch
+++ b/0001-Restore-libjxl-in-Thorium.patch
@@ -491,7 +491,7 @@ index 4628d3ef97b78..3b7b909fe6ee3 100644
 +  {
 +    "name": "enable-jxl",
 +    "owners": [ "eustas@chromium.org", "firsching", "sboukortt", "veluca" ],
-+    "expiry_milestone": 115
++    "expiry_milestone": -1
 +  },
    {
      "name": "enable-keyboard-backlight-toggle",


### PR DESCRIPTION
The expired milestone of jxl is set to 115, but I think this expired milestone is just a marker, it should not cause jxl to expire or become invalid in version 115, but I think it may be safer to change it to -1.

Related issue: https://github.com/Alex313031/thorium-libjxl/issues/3

@Alex313031 