### PR TITLE
Fix devtool error

### DIFF
--- a/src/third_party/devtools-frontend/src/front_end/core/sdk/sdk-meta.ts
+++ b/src/third_party/devtools-frontend/src/front_end/core/sdk/sdk-meta.ts
@@ -969,6 +969,24 @@ Common.Settings.registerSettingExtension({
 
 Common.Settings.registerSettingExtension({
   category: Common.Settings.SettingCategory.RENDERING,
+  settingName: 'jpegXlFormatDisabled',
+  settingType: Common.Settings.SettingType.BOOLEAN,
+  storageType: Common.Settings.SettingStorageType.Session,
+  options: [
+    {
+      value: true,
+      title: i18nLazyString(UIStrings.disableJpegXlFormat),
+    },
+    {
+      value: false,
+      title: i18nLazyString(UIStrings.enableJpegXlFormat),
+    },
+  ],
+  defaultValue: false,
+});
+
+Common.Settings.registerSettingExtension({
+  category: Common.Settings.SettingCategory.RENDERING,
   settingName: 'webpFormatDisabled',
   settingType: Common.Settings.SettingType.BOOLEAN,
   storageType: Common.Settings.SettingStorageType.Session,


### PR DESCRIPTION
The sdk-meta.ts file is missing part of the code related to jpeg-xl, which breaks devtool, now add the missing code back to make devtool work again.

It has passed the test, can be compiled normally, and devtool has also returned to normal.